### PR TITLE
matrix builds for recent galaxy releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,18 @@ language: python
 python:
   - "2.7"
   - "2.6"
-
+env:
+  - GALAXY_VERSION=dev
+  - GALAXY_VERSION=release_15.01
+  - GALAXY_VERSION=release_14.10
+  
 install:
   - python setup.py install
 
 before_script:
   # Install Galaxy
   - cd $HOME
-  - wget https://github.com/galaxyproject/galaxy/archive/dev.tar.gz
+  - wget https://github.com/galaxyproject/galaxy/archive/${GALAXY_VERSION}.tar.gz
   - tar xvzf dev.tar.gz | tail
   - cd galaxy-dev/
   # Copy sample files and fetch eggs

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ before_script:
   - cd $HOME
   - wget https://github.com/galaxyproject/galaxy/archive/${GALAXY_VERSION}.tar.gz
   - tar xvzf dev.tar.gz | tail
-  - cd galaxy-dev/
+  # Releases/dev branch are named differently
+  - cd galaxy-*/
   # Copy sample files and fetch eggs
   - ./scripts/common_startup.sh
   # Create a PostgreSQL database for Galaxy. The default SQLite3 database makes test fail randomly because of "database locked" error.

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
   - wget https://github.com/galaxyproject/galaxy/archive/${GALAXY_VERSION}.tar.gz
   - tar xvzf dev.tar.gz | tail
   # Releases/dev branch are named differently
-  - cd galaxy-*/
+  - cd galaxy-${GALAXY_VERSION}/
   # Copy sample files and fetch eggs
   - ./scripts/common_startup.sh
   # Create a PostgreSQL database for Galaxy. The default SQLite3 database makes test fail randomly because of "database locked" error.

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "2.6"
 env:
   - GALAXY_VERSION=dev
+  - GALAXY_VERSION=release_15.03
   - GALAXY_VERSION=release_15.01
   - GALAXY_VERSION=release_14.10
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_script:
   # Install Galaxy
   - cd $HOME
   - wget https://github.com/galaxyproject/galaxy/archive/${GALAXY_VERSION}.tar.gz
-  - tar xvzf dev.tar.gz | tail
+  - tar xvzf ${GALAXY_VERSION}.tar.gz | tail
   # Releases/dev branch are named differently
   - cd galaxy-${GALAXY_VERSION}/
   # Copy sample files and fetch eggs


### PR DESCRIPTION
Easier than setting up jenkins jobs. Adds an [environment variable](http://docs.travis-ci.com/user/build-configuration/#The-Build-Matrix) for galaxy version, in response to discussion https://github.com/erasche/bioblend/commit/dd89790104f00a358f8ae16905364e558ffae8c9#commitcomment-10027726

Only support relatively recent builds in order to avoid messiness with lack of user-add API route, and the switch from universe_wsgi.ini to galaxy.ini
